### PR TITLE
Add simple (plain) template

### DIFF
--- a/labelcommander/listener.py
+++ b/labelcommander/listener.py
@@ -45,8 +45,9 @@ def handle_print_request(sender, value=None, path=None):
 
             success = main.print_label(
                 job['text'],
-                job.get('qty'),
-                job.get('occurredAt')
+                qty=job.get('qty'),
+                date=job.get('occurredAt'),
+                template=job.get('template')
             )
             if success:
                 # printing succeeded

--- a/labelcommander/main.py
+++ b/labelcommander/main.py
@@ -7,11 +7,11 @@ from . import render
 logger = logging.getLogger(__name__)
 
 
-def print_label(text, qty=None, date=None):
+def print_label(text, qty=None, date=None, template=None):
     try:
         filtered_text = formatter.process(text)
         logger.debug('Printing label: %s', filtered_text)
-        tex_path = render.generate(filtered_text, date=date)
+        tex_path = render.generate(filtered_text, date=date, template=template)
         pdf_path = output.pdftex(tex_path)
         logger.debug('Printing PDF file: %s', pdf_path)
         output.print(pdf_path, qty)

--- a/labelcommander/render.py
+++ b/labelcommander/render.py
@@ -15,7 +15,12 @@ IMAGE_PATH = os.path.join(
     'images'
 )
 
-DEFAULT_TEMPLATE_NAME = 'label.tex'
+TEMPLATES = {
+    'default': 'label.tex',
+    'simple': 'simple_label.tex',
+}
+
+DEFAULT_TEMPLATE = 'default'
 
 # https://tex.stackexchange.com/a/34586
 SPECIAL_TEX_CHARS = {
@@ -61,10 +66,17 @@ def escape_for_tex(body):
     return body
 
 
+def get_template(name):
+    if name is None:
+        return TEMPLATES[DEFAULT_TEMPLATE]
+
+    return TEMPLATES.get(name, TEMPLATES[DEFAULT_TEMPLATE])
+
+
 def render(body, **kwargs):
     escaped_body = escape_for_tex(body)
     date = format_date(kwargs.get('date'))
-    template_name = kwargs.get('template') or DEFAULT_TEMPLATE_NAME
+    template_name = get_template(kwargs.get('template'))
     template = jinja_env.get_template(template_name)
     return template.render(
         image_path='{}/'.format(IMAGE_PATH),

--- a/labelcommander/templates/simple_label.tex
+++ b/labelcommander/templates/simple_label.tex
@@ -1,0 +1,34 @@
+%% Set up document for Dymo 30334 label
+\documentclass[10pt]{memoir}
+\setstocksize{84pt}{156pt}
+\settrimmedsize{84pt}{156pt}{*}
+%% Equal 11pt margins on all four sides
+\setlrmarginsandblock{11pt}{11pt}{*}
+\setulmarginsandblock{11pt}{11pt}{*}
+%% Shrink header/footer variables so they don't take up space
+\setheadfoot{1pt}{1pt}
+\setheaderspaces{1pt}{*}{*}
+\checkandfixthelayout
+
+%% Completely disable headers, footers, and page numbers
+\pagestyle{empty}
+
+%% Set default font to ITC Avant Garde
+\renewcommand{\rmdefault}{pag}
+\sffamily
+
+%% Add adjustbox for scaling
+\usepackage{adjustbox}
+
+%% Main document
+\begin{document}
+\noindent%
+\begin{minipage}[c][\dimexpr\textheight-1pt\relax][c]{\textwidth}
+  \centering
+  \begin{adjustbox}{max width=\textwidth, max totalheight=\textheight, keepaspectratio}
+    \begin{minipage}{\textwidth}
+      \centering\Large\bfseries << body >>
+    \end{minipage}
+  \end{adjustbox}
+\end{minipage}%
+\end{document}


### PR DESCRIPTION
Support multiple templates, and add a second template for plain labels (e.g. without a header or footer).